### PR TITLE
Mime types version fix

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,3 +1,3 @@
 default['build_essential']['compiletime'] = true
 default[:route53][:fog_version] = '1.20'
-default[:mime_types][:version]  = '2.6.2'
+default[:mime_types][:version]  = '1.25.1'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,2 +1,3 @@
 default['build_essential']['compiletime'] = true
 default[:route53][:fog_version] = '1.20'
+default[:mime_types][:version]  = '2.6.2'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,6 +4,6 @@ maintainer_email "darrin@heavywater.ca"
 license          "Apache 2.0"
 description      "Installs/Configures route53"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.3.4"
+version          "0.3.5"
 
 depends 'build-essential'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -50,10 +50,14 @@ chef_gem "mime-types" do
   version node[:mime_types][:version] 
 end 
 
+Gem.clear_paths
+require 'mime-types' 
+
 chef_gem "fog" do
   action :install
   version node['route53']['fog_version']
+  retries 1 
 end
 
-require 'rubygems'
-Gem.clear_paths
+#Gem.clear_paths
+#require 'rubygems'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -41,6 +41,15 @@ elsif node['platform_family'] == 'rhel'
    xslt.run_action( :install )
 end
 
+# because the constraint on mime-types in >= 0 it resolves to 3.0.0 
+# which requires ruby 2.0 which conflicts with existing ruby 
+# versions installed by omnibus for chef-client v 11.16.4
+# so to fix this we download v 2.6.x of mime-types. 
+chef_gem "mime-types" do 
+  action :install 
+  version node[:mime_types][:version] 
+end 
+
 chef_gem "fog" do
   action :install
   version node['route53']['fog_version']


### PR DESCRIPTION
fog installs mime-types version 3.0.0 by default which has a hard dependency of ruby 2.0.0 which conflicts with version of ruby installed by omnibus for chef-client ( 11.16.4). 

Therefore, to break this dependency chain, we first download a compatible version of mime-types. 
