### PR TITLE
install different fog versions by default depending if the server is running chef-client 11 or 12

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,4 +1,11 @@
 default['build_essential']['compiletime'] = true
-default[:route53][:fog_version] = '1.20'
+
+chef_version = `chef-client -v`.strip.split(':')[1].to_f
+if chef_version < 12
+  default[:route53][:fog_version] = '1.5.0'
+else
+  default[:route53][:fog_version] = '1.11.0'
+end
+
 default[:mime_types][:version]  = '1.25.1'
 default[:nokogiri][:version]  = '1.5.11'


### PR DESCRIPTION
Chef 11 and Chef 12 don't use same embedded Ruby versions. We need to install the right Fog version accordingly.